### PR TITLE
Add Indexers page

### DIFF
--- a/docs/Indexers.md
+++ b/docs/Indexers.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 10
+title: "Indexers"
+---
+
+# Indexers
+
+Envio is the data layer for blockchain apps. It gives AB developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud.
+
+## Envio
+
+[Envio](https://envio.dev/?utm_source=ab&utm_medium=partner-docs) is a data indexing framework for building backends that serve onchain data to your app.
+
+AB is supported on Envio HyperSync, a high-speed data source that can be up to 2000x faster than standard RPC. You can index AB with HyperIndex, define the events and entities you care about, and serve them through a ready to use GraphQL API.
+
+### Network support
+
+| Item | Value |
+| --- | --- |
+| Network | AB Mainnet |
+| Chain ID | 36888 |
+| HyperSync endpoint | `https://ab.hypersync.xyz` |
+
+### Features
+
+* Real-time and historical onchain data through a single GraphQL API
+* HyperSync access up to 2000x faster than standard RPC
+* Flexible schema and event handlers written in familiar languages
+* Managed hosting on Envio Cloud, or self host wherever you prefer
+
+### Resources
+
+* [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=ab&utm_medium=partner-docs)
+* [Benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=ab&utm_medium=partner-docs)

--- a/docs/Indexers.md
+++ b/docs/Indexers.md
@@ -9,7 +9,7 @@ Envio is the data layer for blockchain apps. It gives AB developers the fastest,
 
 ## Envio
 
-[Envio](https://envio.dev/?utm_source=ab&utm_medium=partner-docs) is a data indexing framework for building backends that serve onchain data to your app.
+[Envio](https://envio.dev/?utm_source=ab&utm_medium=partner-docs) provides HyperIndex, a full-featured indexing framework, and HyperSync, a high-speed data engine, so AB developers can turn smart contract events into a queryable GraphQL API.
 
 AB is supported on Envio HyperSync, a high-speed data source that can be up to 2000x faster than standard RPC. You can index AB with HyperIndex, define the events and entities you care about, and serve them through a ready to use GraphQL API.
 


### PR DESCRIPTION
Adds a new Indexers page introducing Envio as an option for accessing AB onchain data. The page lives under docs and is picked up by the autogenerated sidebar. Style and frontmatter match the existing docs pages.